### PR TITLE
Fix CMake target to build MermaidJs plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-project(PlantUmlWebView LANGUAGES CXX)
+project(MermaidJsWebView LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -10,21 +10,21 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_SOURCE_DIR}/dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY  ${CMAKE_SOURCE_DIR}/dist)
 
 # build the WLX as a MODULE so it produces a single DLL
-add_library(PlantUmlWebView MODULE
-    src/plantuml_wlx_ev2.cpp
+add_library(MermaidJsWebView MODULE
+    src/mermaidjs_wlx_ev2.cpp
 )
 
-target_compile_features(PlantUmlWebView PRIVATE cxx_std_17)
-target_compile_definitions(PlantUmlWebView PRIVATE UNICODE _UNICODE NOMINMAX)
-target_include_directories(PlantUmlWebView PRIVATE
+target_compile_features(MermaidJsWebView PRIVATE cxx_std_17)
+target_compile_definitions(MermaidJsWebView PRIVATE UNICODE _UNICODE NOMINMAX)
+target_include_directories(MermaidJsWebView PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/WebView2/build/native/include
 )
-target_link_libraries(PlantUmlWebView PRIVATE shlwapi)
+target_link_libraries(MermaidJsWebView PRIVATE shlwapi)
 
 # Name it exactly as TC expects and use the .wlx64 extension
-set_target_properties(PlantUmlWebView PROPERTIES
-    OUTPUT_NAME "PlantUmlWebView"
+set_target_properties(MermaidJsWebView PROPERTIES
+    OUTPUT_NAME "MermaidJsWebView"
     PREFIX ""                 # no "lib" prefix anywhere
-    SUFFIX ".wlx64"           # produce PlantUmlWebView.wlx64 instead of .dll
+    SUFFIX ".wlx64"           # produce MermaidJsWebView.wlx64 instead of .dll
 )
 


### PR DESCRIPTION
## Summary
- update the CMake project and target names to MermaidJsWebView
- point the build to the mermaid-specific source file and output artifact name

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_e_68d2ef58516c8322adba16a86ab97ce4