### PR TITLE
Remove nested zip files from package staging

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -117,6 +117,12 @@ jobs:
             Remove-Item -Force $tarPath
           }
 
+          $nodeModules = Join-Path -Path $mermaidDest -ChildPath 'node_modules'
+          if (Test-Path $nodeModules) {
+            Get-ChildItem -Path $nodeModules -Recurse -Filter '*.zip' -File -ErrorAction SilentlyContinue |
+              Remove-Item -Force -ErrorAction SilentlyContinue
+          }
+
       - name: Create ZIP (no nesting)
         run: |
           Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- ensure the release workflow deletes any zip archives copied from the bundled MermaidJS runtime before zipping the plugin

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2f706a3748322a610125fc9ff8fcf