### PR TITLE
Update default CLI path and extensions

### DIFF
--- a/mermaidjswebview.ini
+++ b/mermaidjswebview.ini
@@ -7,14 +7,14 @@ prefer=svg
 [mmdc]
 ; If empty, the plugin will auto-try "mmdc.bat" placed next to the plugin DLL.
 ; You can also point to a custom CLI path here.
-cli=mmdc.bat
+cli=mermaidjs\mmdc.bat
 
 ; Kill the CLI process if it hangs (ms)
 timeout_ms=8000
 
 [detect]
 ; Reported detect string for Total Commander installation
-string=EXT="MERMAID" | EXT="MM"
+string=EXT=".MERMAID" | EXT=".MMD"
 
 [debug]
 ; Optional log file path (defaults to mermaidjswebview.log next to the plugin DLL)

--- a/resources/pluginst.inf
+++ b/resources/pluginst.inf
@@ -5,4 +5,4 @@ type=wlx64
 file=MermaidJsWebView.wlx64
 name=MermaidJs WebView Lister
 description=MermaidJs preview via WebView2
-defaultextension=mermaid mmd
+defaultextension=.mermaid .mmd

--- a/src/mermaidjs_wlx_ev2.cpp
+++ b/src/mermaidjs_wlx_ev2.cpp
@@ -30,7 +30,7 @@ using namespace Microsoft::WRL;
 
 // ---------------------- Config ----------------------
 static std::wstring g_prefer    = L"svg";           // "svg" or "png"
-static std::string  g_detectA   = R"(EXT="MERMAID" | EXT="MM")";
+static std::string  g_detectA   = R"(EXT=".MERMAID" | EXT=".MMD")";
 
 static std::wstring g_mmdcPath;                     // If empty: auto-detect moduleDir\mmdc.(bat|cmd|exe)
 static std::wstring g_logPath;                      // If empty: moduleDir\mermaidjswebview.log


### PR DESCRIPTION
## Summary
- point the default Mermaid CLI path in the INI to the bundled mermaidjs\mmdc.bat
- advertise .mermaid and .mmd extensions in the INI, plugin installer, and detect string

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2ffa78bf0832287ab431e81ff203c