### PR TITLE
Fix PNG format selection in web viewer

### DIFF
--- a/src/mermaidjs_wlx_ev2.cpp
+++ b/src/mermaidjs_wlx_ev2.cpp
@@ -799,6 +799,77 @@ static const wchar_t kHtmlPart2[] = LR"HTML(
       svg.style.color = '#000000';
     };
 
+    const convertSvgToPng = (svgElement) => {
+      return new Promise((resolve) => {
+        if (!svgElement) {
+          resolve('');
+          return;
+        }
+        try {
+          const serializer = new XMLSerializer();
+          const svgMarkup = serializer.serializeToString(svgElement);
+          const blob = new Blob([svgMarkup], { type: 'image/svg+xml' });
+          const objectUrl = URL.createObjectURL(blob);
+          const image = new Image();
+          image.decoding = 'async';
+          image.crossOrigin = 'anonymous';
+
+          image.onload = () => {
+            try {
+              let width = Number(svgElement.getAttribute('width')) || 0;
+              let height = Number(svgElement.getAttribute('height')) || 0;
+              if (!width || !height) {
+                const viewBox = svgElement.viewBox?.baseVal;
+                if (viewBox && viewBox.width && viewBox.height) {
+                  width = viewBox.width;
+                  height = viewBox.height;
+                } else {
+                  const rect = svgElement.getBoundingClientRect();
+                  width = rect.width;
+                  height = rect.height;
+                }
+              }
+
+              width = Math.max(1, Math.round(width));
+              height = Math.max(1, Math.round(height));
+
+              const canvas = document.createElement('canvas');
+              const scale = window.devicePixelRatio || 1;
+              canvas.width = width * scale;
+              canvas.height = height * scale;
+              const ctx = canvas.getContext('2d');
+              if (!ctx) {
+                resolve('');
+                return;
+              }
+
+              if (scale !== 1) {
+                ctx.setTransform(scale, 0, 0, scale, 0, 0);
+              }
+              ctx.clearRect(0, 0, width, height);
+              ctx.drawImage(image, 0, 0, width, height);
+              resolve(canvas.toDataURL('image/png'));
+            } catch (err) {
+              console.warn('Failed to convert SVG to PNG', err);
+              resolve('');
+            } finally {
+              URL.revokeObjectURL(objectUrl);
+            }
+          };
+
+          image.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            resolve('');
+          };
+
+          image.src = objectUrl;
+        } catch (err) {
+          console.warn('Failed to start SVG to PNG conversion', err);
+          resolve('');
+        }
+      });
+    };
+
     const encodeBase64 = (text) => {
       try {
         if (typeof TextEncoder !== 'undefined') {
@@ -941,17 +1012,15 @@ static const wchar_t kHtmlPart2[] = LR"HTML(
       updateSaveState();
       updateCopyState();
       notifyHost();
-      if (window.saveSvgAsPng && saveSvgAsPng.svgAsPngUri) {
-        const requestId = ++pngRequestId;
-        saveSvgAsPng.svgAsPngUri(svgElement, { backgroundColor: '#ffffff' }, (uri) => {
-          if (requestId !== pngRequestId) { return; }
-          renderState.pngDataUrl = uri || '';
-          applyFormatDisplay();
-          updateSaveState();
-          updateCopyState();
-          notifyHost();
-        });
-      }
+      const requestId = ++pngRequestId;
+      convertSvgToPng(svgElement).then((uri) => {
+        if (requestId !== pngRequestId) { return; }
+        renderState.pngDataUrl = uri || '';
+        applyFormatDisplay();
+        updateSaveState();
+        updateCopyState();
+        notifyHost();
+      });
     };
 
     const saveDiagram = () => {


### PR DESCRIPTION
## Summary
- replace the third-party PNG conversion in the web shell with an internal SVG-to-PNG canvas conversion helper
- ensure PNG data URLs are generated so the PNG preview, save, and copy controls stay enabled when PNG is selected

## Testing
- not run (web-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d36ce21408832288c695d7278610da