### PR TITLE
Handle foreignObject text when exporting web PNG

### DIFF
--- a/src/mermaidjs_wlx_ev2.cpp
+++ b/src/mermaidjs_wlx_ev2.cpp
@@ -728,13 +728,37 @@ static const wchar_t kHtmlPart1[] = LR"HTML(<!doctype html>
     #diagram-container { width: 100%; }
     #diagram-container svg { background-color: #ffffff !important; color: #000000 !important; }
     #diagram-container .mermaid { background-color: #ffffff !important; color: #000000 !important; }
+    #diagram-container svg .edgeLabel rect {
+      fill: rgba(255, 255, 255, 0.92) !important;
+      stroke: rgba(0, 0, 0, 0.35) !important;
+    }
+    #diagram-container svg .edgeLabel text,
+    #diagram-container svg .edgeLabel tspan {
+      fill: #1a1a1a !important;
+    }
     #png-preview { display: none; max-width: 100%; height: auto; }
     img, svg { max-width: 100%; height: auto; }
     .err { padding: 12px 14px; border-radius: 10px; background: color-mix(in oklab, Canvas 85%, red 15%); }
   </style>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({ startOnLoad: true, theme: 'default', themeVariables: { background: '#ffffff' } });
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'default',
+      themeVariables: { background: '#ffffff' },
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+      class: { htmlLabels: false },
+      state: { htmlLabels: false },
+      er: { htmlLabels: false },
+      mindmap: { htmlLabels: false },
+      journey: { htmlLabels: false },
+      gantt: { htmlLabels: false },
+      gitGraph: { htmlLabels: false },
+      pie: { htmlLabels: false },
+      requirement: { htmlLabels: false },
+      timeline: { htmlLabels: false },
+    });
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/save-svg-as-png/1.4.17/saveSvgAsPng.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.10/umd.min.js"></script>
@@ -819,6 +843,107 @@ static const wchar_t kHtmlPart2a[] = LR"HTML(
       return clone;
     };
 
+    const inlineTextStyles = (sourceSvg, targetSvg) => {
+      if (!sourceSvg || !targetSvg) { return; }
+      const sourceNodes = sourceSvg.querySelectorAll('text, tspan');
+      const targetNodes = targetSvg.querySelectorAll('text, tspan');
+      if (sourceNodes.length !== targetNodes.length) { return; }
+      sourceNodes.forEach((sourceNode, index) => {
+        const targetNode = targetNodes[index];
+        if (!targetNode) { return; }
+        const computed = window.getComputedStyle(sourceNode);
+        if (!computed) { return; }
+        const setAttr = (name, value) => {
+          if (!value) { return; }
+          targetNode.setAttribute(name, value);
+        };
+        setAttr('font-family', computed.fontFamily);
+        setAttr('font-size', computed.fontSize);
+        setAttr('font-weight', computed.fontWeight);
+        setAttr('font-style', computed.fontStyle);
+        setAttr('letter-spacing', computed.letterSpacing);
+        setAttr('text-anchor', computed.textAnchor);
+        const fill = computed.fill && computed.fill !== 'none' ? computed.fill : '#000000';
+        setAttr('fill', fill);
+        if (computed.stroke && computed.stroke !== 'none') {
+          setAttr('stroke', computed.stroke);
+          setAttr('stroke-width', computed.strokeWidth);
+        } else {
+          targetNode.removeAttribute('stroke');
+          targetNode.removeAttribute('stroke-width');
+        }
+      });
+    };
+
+    const replaceForeignObjectText = (sourceSvg, targetSvg) => {
+      if (!sourceSvg || !targetSvg) { return; }
+      const sourceNodes = sourceSvg.querySelectorAll('foreignObject');
+      const targetNodes = targetSvg.querySelectorAll('foreignObject');
+      if (!sourceNodes.length || sourceNodes.length !== targetNodes.length) { return; }
+      sourceNodes.forEach((sourceNode, index) => {
+        const targetNode = targetNodes[index];
+        if (!targetNode) { return; }
+        let bbox = null;
+        try {
+          bbox = typeof sourceNode.getBBox === 'function' ? sourceNode.getBBox() : null;
+        } catch (err) {
+          bbox = null;
+        }
+        if (!bbox || !bbox.width || !bbox.height) { return; }
+
+        const contentEl = sourceNode.querySelector('*');
+        const textSource = contentEl || sourceNode;
+        const rawText = (textSource.textContent || '').replace(/\r\n/g, '\n');
+        const lines = rawText.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+        if (!lines.length) { return; }
+
+        const doc = targetSvg.ownerDocument || document;
+        const textEl = doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+
+        const computed = contentEl ? window.getComputedStyle(contentEl) : null;
+        const fontFamily = computed?.fontFamily || 'sans-serif';
+        const fontSize = computed?.fontSize || '14px';
+        const fontWeight = computed?.fontWeight || '';
+        const fontStyle = computed?.fontStyle || '';
+        const letterSpacing = computed?.letterSpacing || '';
+        const textTransform = computed?.textTransform || '';
+        const color = computed?.color || '#000000';
+
+        const fontSizeValue = parseFloat(fontSize) || 14;
+        const lineHeightRaw = computed?.lineHeight || '';
+        let lineHeightValue = parseFloat(lineHeightRaw);
+        if (!isFinite(lineHeightValue) || lineHeightValue <= 0) {
+          lineHeightValue = fontSizeValue * 1.2;
+        }
+
+        const centerX = bbox.x + bbox.width / 2;
+        const centerY = bbox.y + bbox.height / 2;
+        textEl.setAttribute('x', String(centerX));
+        textEl.setAttribute('y', String(centerY));
+        textEl.setAttribute('text-anchor', 'middle');
+        textEl.setAttribute('dominant-baseline', 'middle');
+        textEl.setAttribute('font-family', fontFamily);
+        textEl.setAttribute('font-size', fontSize);
+        if (fontWeight && fontWeight !== 'normal') { textEl.setAttribute('font-weight', fontWeight); }
+        if (fontStyle && fontStyle !== 'normal') { textEl.setAttribute('font-style', fontStyle); }
+        if (letterSpacing && letterSpacing !== 'normal') { textEl.setAttribute('letter-spacing', letterSpacing); }
+        if (textTransform && textTransform !== 'none') { textEl.setAttribute('text-transform', textTransform); }
+        textEl.setAttribute('fill', color || '#000000');
+
+        const baselineShift = -((lines.length - 1) / 2) * lineHeightValue;
+        lines.forEach((line, lineIndex) => {
+          const tspan = doc.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+          const dy = lineIndex === 0 ? baselineShift : lineHeightValue;
+          tspan.setAttribute('x', String(centerX));
+          tspan.setAttribute('dy', String(dy));
+          tspan.textContent = line;
+          textEl.appendChild(tspan);
+        });
+
+        targetNode.replaceWith(textEl);
+      });
+    };
+
     const measureSvgDimensions = (svgElement) => {
       let width = Number(svgElement.getAttribute('width')) || 0;
       let height = Number(svgElement.getAttribute('height')) || 0;
@@ -840,6 +965,8 @@ static const wchar_t kHtmlPart2a[] = LR"HTML(
 
     const buildExportSvg = (svgElement) => {
       const clone = sanitizeSvgForCanvas(svgElement) || svgElement.cloneNode(true);
+      inlineTextStyles(svgElement, clone);
+      replaceForeignObjectText(svgElement, clone);
       const { width, height } = measureSvgDimensions(svgElement);
       if (!clone.getAttribute('width')) { clone.setAttribute('width', String(width)); }
       if (!clone.getAttribute('height')) { clone.setAttribute('height', String(height)); }


### PR DESCRIPTION
## Summary
- disable HTML label rendering across Mermaid diagram types in the web shell to avoid foreignObject-only text
- convert any remaining foreignObject labels into positioned <text> elements before rasterizing SVGs for PNG export
- keep the inlined font/stroke styling when cloning the SVG so rendered PNGs retain typography
- force light backgrounds and dark text on edge labels so arrow captions stay legible in both the live SVG and exported PNG

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43365ef1c832299d3478cb63dfe53